### PR TITLE
duck-pong.js: Prevent ball from glitching outside the screen

### DIFF
--- a/assets/js/levels/duck-pong.js
+++ b/assets/js/levels/duck-pong.js
@@ -162,11 +162,14 @@ function update(deltaTime) {
 		gameState.ball.y += gameState.ball.speedY * deltaTime;
 	}
 
-	if ( gameState.ball.x > gameState.level.width - gameState.ball.width ) {
+	var ballMaxX = gameState.level.width - gameState.ball.width;
+	if ( gameState.ball.x > ballMaxX ) {
 		gameState.ball.speedX *= -1;
+		gameState.ball.x = 2 * ballMaxX - gameState.ball.x; // Mirror in ballMaxX
 	}
 	if ( gameState.ball.x < 0 ) {
 		gameState.ball.speedX *= -1;
+		gameState.ball.x *= -1;
 	}
 
 	// Ball hitting character


### PR DESCRIPTION
If, thanks to lag, `ball.x` becomes _too_ negative, `speedX` would be multiplied by `-1` for all subsequent frames, keeping the ball to the left of the wall.

As a fix, we mirror the ball w.r.t. the "wall" that it bounced into.
- When it bounces on the left wall, simply flip sign of x-coordinate.
- And on the right, calculate what the mirrored x-coordinate would be.

This basically makes it look as if a small bounce happened _during_ the current animation frame,
instead of bouncing _in between_ two animation frames.